### PR TITLE
Add RTS statistics tools

### DIFF
--- a/Tools/RTS_EntityStats.json
+++ b/Tools/RTS_EntityStats.json
@@ -1,0 +1,136 @@
+{
+  "units": {
+    "orc": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/orc.prefab",
+      "maxHealth": 70,
+      "initialHealth": 70,
+      "attackDamageUnit": 13,
+      "attackDamageBuilding": 13
+    },
+    "archer_level2": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/archer_level2.prefab",
+      "maxHealth": 60,
+      "initialHealth": 70,
+      "attackDamageUnit": 8,
+      "attackDamageBuilding": 8
+    },
+    "villager": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/villager.prefab",
+      "maxHealth": 40,
+      "initialHealth": 40
+    },
+    "spacecraft": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/spacecraft.prefab",
+      "maxHealth": 130,
+      "initialHealth": 130,
+      "attackDamageUnit": 14,
+      "attackDamageBuilding": 22
+    },
+    "heavy_infantry": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/heavy_infantry.prefab",
+      "maxHealth": 170,
+      "initialHealth": 170,
+      "attackDamageUnit": 17,
+      "attackDamageBuilding": 17
+    },
+    "healer": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/healer.prefab",
+      "maxHealth": 80,
+      "initialHealth": 80
+    },
+    "light_infantry": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/light_infantry.prefab",
+      "maxHealth": 125,
+      "initialHealth": 125,
+      "attackDamageUnit": 13,
+      "attackDamageBuilding": 13
+    },
+    "archer_level1": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/archer_level1.prefab",
+      "maxHealth": 70,
+      "initialHealth": 70,
+      "attackDamageUnit": 14,
+      "attackDamageBuilding": 14
+    },
+    "catapult": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/catapult.prefab",
+      "maxHealth": 130,
+      "initialHealth": 130,
+      "attackDamageUnit": 14,
+      "attackDamageBuilding": 22
+    },
+    "converter": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/converter.prefab",
+      "maxHealth": 80,
+      "initialHealth": 80
+    },
+    "siege_tower": {
+      "prefab": "Assets/RTS Engine/Demo/UnitExtension/Resources/Prefabs/siege_tower.prefab",
+      "maxHealth": 120,
+      "initialHealth": 120
+    }
+  },
+  "buildings": {
+    "house": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/house.prefab",
+      "maxHealth": 400,
+      "initialHealth": 1
+    },
+    "barracks_level2": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/barracks_level2.prefab",
+      "maxHealth": 1400,
+      "initialHealth": 1,
+      "attackDamageUnit": 14,
+      "attackDamageBuilding": 14
+    },
+    "temple": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/temple.prefab",
+      "maxHealth": 800,
+      "initialHealth": 1
+    },
+    "tower_level2": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/tower_level2.prefab",
+      "maxHealth": 900,
+      "initialHealth": 1,
+      "attackDamageUnit": 8,
+      "attackDamageBuilding": 8
+    },
+    "barracks_level1": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/barracks_level1.prefab",
+      "maxHealth": 1200,
+      "initialHealth": 1
+    },
+    "granary": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/granary.prefab",
+      "maxHealth": 1000,
+      "initialHealth": 1
+    },
+    "siege_factory": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/siege_factory.prefab",
+      "maxHealth": 1200,
+      "initialHealth": 1
+    },
+    "tower_level1": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/tower_level1.prefab",
+      "maxHealth": 750,
+      "initialHealth": 1,
+      "attackDamageUnit": 14,
+      "attackDamageBuilding": 14
+    },
+    "university": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/university.prefab",
+      "maxHealth": 800,
+      "initialHealth": 1
+    },
+    "farm": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/farm.prefab",
+      "maxHealth": 400,
+      "initialHealth": 1
+    },
+    "town_center": {
+      "prefab": "Assets/RTS Engine/Demo/BuildingExtension/Resources/Prefabs/town_center.prefab",
+      "maxHealth": 2500,
+      "initialHealth": 1
+    }
+  }
+}

--- a/Tools/apply_entity_stats.py
+++ b/Tools/apply_entity_stats.py
@@ -1,0 +1,36 @@
+import os
+import re
+import json
+
+STATS_FILE = os.path.join('Tools', 'RTS_EntityStats.json')
+pattern_health = re.compile(r"maxHealth:\s*\d+")
+pattern_initial = re.compile(r"initialHealth:\s*\d+")
+pattern_damage = re.compile(r"(damage:\s*\n\s*enabled:\s*1\s*\n\s*data:\s*\n\s*unit:\s*)(\d+)(\s*\n\s*building:\s*)(\d+)")
+
+def apply_stats(path, stats):
+    with open(path, 'r') as f:
+        content = f.read()
+    if 'maxHealth' in stats:
+        content = re.sub(pattern_health, f"maxHealth: {stats['maxHealth']}", content)
+    if 'initialHealth' in stats:
+        content = re.sub(pattern_initial, f"initialHealth: {stats['initialHealth']}", content)
+    if 'attackDamageUnit' in stats and 'attackDamageBuilding' in stats:
+        content = re.sub(pattern_damage,
+                        lambda m: f"{m.group(1)}{stats['attackDamageUnit']}{m.group(3)}{stats['attackDamageBuilding']}",
+                        content)
+    with open(path, 'w') as f:
+        f.write(content)
+
+def main():
+    with open(STATS_FILE, 'r') as f:
+        data = json.load(f)
+    for group in ('units', 'buildings'):
+        if group in data:
+            for name, entry in data[group].items():
+                path = entry.get('prefab')
+                if path and os.path.exists(path):
+                    apply_stats(path, entry)
+                    print(f"Updated {path}")
+
+if __name__ == '__main__':
+    main()

--- a/Tools/generate_entity_stats.py
+++ b/Tools/generate_entity_stats.py
@@ -1,0 +1,49 @@
+import os
+import re
+import json
+
+UNIT_DIR = os.path.join('Assets', 'RTS Engine', 'Demo', 'UnitExtension', 'Resources', 'Prefabs')
+BUILDING_DIR = os.path.join('Assets', 'RTS Engine', 'Demo', 'BuildingExtension', 'Resources', 'Prefabs')
+
+pattern_health = re.compile(r"maxHealth:\s*(\d+)")
+pattern_initial = re.compile(r"initialHealth:\s*(\d+)")
+pattern_damage = re.compile(r"damage:\s*\n\s*enabled:\s*1\s*\n\s*data:\s*\n\s*unit:\s*(\d+)\s*\n\s*building:\s*(\d+)")
+
+
+def parse_prefab(path):
+    with open(path, 'r') as f:
+        content = f.read()
+    stats = {}
+    m = pattern_health.search(content)
+    if m:
+        stats['maxHealth'] = int(m.group(1))
+    m = pattern_initial.search(content)
+    if m:
+        stats['initialHealth'] = int(m.group(1))
+    m = pattern_damage.search(content)
+    if m:
+        stats['attackDamageUnit'] = int(m.group(1))
+        stats['attackDamageBuilding'] = int(m.group(2))
+    return stats
+
+def gather_entities(directory):
+    entities = {}
+    for fname in os.listdir(directory):
+        if not fname.endswith('.prefab'):
+            continue
+        path = os.path.join(directory, fname)
+        stats = parse_prefab(path)
+        if stats:
+            entities[fname.replace('.prefab','')] = {'prefab': path, **stats}
+    return entities
+
+def main():
+    data = {
+        'units': gather_entities(UNIT_DIR),
+        'buildings': gather_entities(BUILDING_DIR)
+    }
+    with open('Tools/RTS_EntityStats.json', 'w') as f:
+        json.dump(data, f, indent=2)
+
+if __name__ == '__main__':
+    main()

--- a/Tools/progress_rts.log
+++ b/Tools/progress_rts.log
@@ -1,0 +1,2 @@
+Sat Jul 12 10:39:20 UTC 2025 - Initialized progress log
+Sat Jul 12 10:40:30 UTC 2025 - Generated entity stats summary


### PR DESCRIPTION
## Summary
- add JSON summary of demo faction units/buildings
- provide script to auto-generate stats from prefabs
- provide script to update prefabs from summary
- track progress in new log file

## Testing
- `python3 Tools/generate_entity_stats.py`
- `python3 Tools/apply_entity_stats.py`

------
https://chatgpt.com/codex/tasks/task_b_68723ac618e483329d16715ce27ee53f