### PR TITLE
Enable prefab creation from template

### DIFF
--- a/RTS_progress.txt
+++ b/RTS_progress.txt
@@ -1,0 +1,1 @@
+Sat Jul 12 12:53:00 UTC 2025 - Updated apply_entity_stats.py to auto-create prefabs from template

--- a/Tools/apply_entity_stats.py
+++ b/Tools/apply_entity_stats.py
@@ -1,6 +1,10 @@
 import os
 import re
 import json
+import shutil
+
+TEMPLATE_UNIT_PREFAB = os.path.join('Assets', 'RTS Engine', 'Demo', 'UnitExtension', 'Resources', 'Prefabs', 'villager.prefab')
+TEMPLATE_BUILDING_PREFAB = os.path.join('Assets', 'RTS Engine', 'Demo', 'BuildingExtension', 'Resources', 'Prefabs', 'house.prefab')
 
 STATS_FILE = os.path.join('Tools', 'RTS_EntityStats.json')
 pattern_health = re.compile(r"maxHealth:\s*\d+")
@@ -28,7 +32,16 @@ def main():
         if group in data:
             for name, entry in data[group].items():
                 path = entry.get('prefab')
-                if path and os.path.exists(path):
+                if not path:
+                    continue
+
+                if not os.path.exists(path):
+                    template = TEMPLATE_UNIT_PREFAB if group == 'units' else TEMPLATE_BUILDING_PREFAB
+                    os.makedirs(os.path.dirname(path), exist_ok=True)
+                    shutil.copy(template, path)
+                    print(f"Created {path} from template {template}")
+
+                if os.path.exists(path):
                     apply_stats(path, entry)
                     print(f"Updated {path}")
 


### PR DESCRIPTION
## Summary
- allow applying entity stats script to create a prefab when one does not exist
- log the change in `RTS_progress.txt`

## Testing
- `python3 Tools/apply_entity_stats.py`

------
https://chatgpt.com/codex/tasks/task_b_68723f5ee1f08332937082273bb0aa59